### PR TITLE
Switch API to use opaque keys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@ethercast/backend-model": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/@ethercast/backend-model/-/backend-model-0.0.13.tgz",
-      "integrity": "sha512-xfzjMlxr90ZuMsGqUBWlkeokmNSAalaiYBH7LnK5AAWIWQk8SU7IT6obTRcYnZijEn3pZ6UzsLNLiaUcbUQ7Hg==",
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/@ethercast/backend-model/-/backend-model-0.0.15.tgz",
+      "integrity": "sha512-LJrev7rFAEQ80vYzDNE4i/I8POXay5fjSzJX+SvaLHeS6YRimonKzQfpu+AobDK0gStp55tdsHZBED0rkpTwmA==",
       "requires": {
         "url-regex": "4.1.1"
       }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "webpack-node-externals": "^1.6.0"
   },
   "dependencies": {
-    "@ethercast/backend-model": "0.0.13",
+    "@ethercast/backend-model": "0.0.15",
     "@ethercast/calculate-signature": "0.0.1",
     "@ethercast/message-compressor": "0.0.0",
     "@ethercast/model": "0.0.16",

--- a/serverless.yml
+++ b/serverless.yml
@@ -78,6 +78,8 @@ provider:
     LOG_QUEUE_NAME: ${self:custom.logQueueName}
     TX_QUEUE_NAME: ${self:custom.txQueueName}
     GET_ABIS_LAMBDA_NAME: ${self:custom.getAbisLambdaName}
+    TOKEN_ISSUER: ${self:custom.tokenIssuer}
+    TOKEN_AUDIENCE: ${self:custom.tokenAudience}
   iamRoleStatements:
     - Effect: Allow
       Action:

--- a/serverless.yml
+++ b/serverless.yml
@@ -25,7 +25,6 @@ custom:
   dynamoTargetUtilitzation: ${opt:dynamoTargetUtilitzation, env:dynamoTargetUtilitzation, "0.6"}
   tokenIssuer: ${opt:tokenIssuer, "https://ethercast.auth0.com/"}
   tokenAudience: ${opt:tokenAudience, "https://api.ethercast.io"}
-  tokenSecret: ${opt:tokenSecret}
   logLevel: ${opt:logLevel, "info"}
   capacities:
     - table: SubscriptionsTable  # DynamoDB Resource
@@ -51,7 +50,7 @@ custom:
         minimum: ${self:custom.baseDynamoDDBCapacity}        # Minimum write capacity
         maximum: ${self:custom.maxDynamoDDBCapacity}      # Maximum write capacity
         usage: ${self:custom.dynamoTargetUtilitzation}        # Targeted usage percentage
-    - table: ApiKeysReceiptsTable  # DynamoDB Resource
+    - table: ApiKeysTable  # DynamoDB Resource
       index:
         - ByUser
       read:
@@ -73,9 +72,6 @@ provider:
     SUBSCRIPTIONS_TABLE: ${self:custom.subscriptionsTable}
     WEBHOOK_RECEIPTS_TABLE: ${self:custom.receiptsTable}
     API_KEYS_TABLE: ${self:custom.apiKeysTable}
-    TOKEN_ISSUER: ${self:custom.tokenIssuer}
-    TOKEN_AUDIENCE: ${self:custom.tokenAudience}
-    TOKEN_SECRET: ${self:custom.tokenSecret}
     LOG_NOTIFICATION_TOPIC_NAME: ${self:custom.logNotificationTopicName}
     TX_NOTIFICATION_TOPIC_NAME: ${self:custom.txNotificationTopicName}
     SEND_WEBHOOK_LAMBDA_NAME: ${self:custom.sendWebhookLambdaName}
@@ -174,7 +170,7 @@ functions:
           authorizer:
             name: auth
             resultTtlInSeconds: 300
-            type: token
+            type: request
           cors:
             origin: '*'
             headers:
@@ -182,6 +178,7 @@ functions:
               - X-Amz-Date
               - Authorization
               - X-Api-Key
+              - X-Api-Secret
               - X-Amz-Security-Token
               - X-Amz-User-Agent
             allowCredentials: true
@@ -195,7 +192,7 @@ functions:
           authorizer:
             name: auth
             resultTtlInSeconds: 300
-            type: token
+            type: request
           cors:
             origin: '*'
             headers:
@@ -203,6 +200,7 @@ functions:
               - X-Amz-Date
               - Authorization
               - X-Api-Key
+              - X-Api-Secret
               - X-Amz-Security-Token
               - X-Amz-User-Agent
             allowCredentials: true
@@ -216,7 +214,7 @@ functions:
           authorizer:
             name: auth
             resultTtlInSeconds: 300
-            type: token
+            type: request
           cors:
             origin: '*'
             headers:
@@ -224,6 +222,7 @@ functions:
               - X-Amz-Date
               - Authorization
               - X-Api-Key
+              - X-Api-Secret
               - X-Amz-Security-Token
               - X-Amz-User-Agent
             allowCredentials: true
@@ -237,7 +236,7 @@ functions:
           authorizer:
             name: auth
             resultTtlInSeconds: 300
-            type: token
+            type: request
           cors:
             origin: '*'
             headers:
@@ -245,6 +244,7 @@ functions:
               - X-Amz-Date
               - Authorization
               - X-Api-Key
+              - X-Api-Secret
               - X-Amz-Security-Token
               - X-Amz-User-Agent
             allowCredentials: true
@@ -258,7 +258,7 @@ functions:
           authorizer:
             name: auth
             resultTtlInSeconds: 300
-            type: token
+            type: request
           cors:
             origin: '*'
             headers:
@@ -266,6 +266,7 @@ functions:
               - X-Amz-Date
               - Authorization
               - X-Api-Key
+              - X-Api-Secret
               - X-Amz-Security-Token
               - X-Amz-User-Agent
             allowCredentials: true
@@ -279,7 +280,7 @@ functions:
           authorizer:
             name: auth
             resultTtlInSeconds: 300
-            type: token
+            type: request
           cors:
             origin: '*'
             headers:
@@ -287,6 +288,7 @@ functions:
               - X-Amz-Date
               - Authorization
               - X-Api-Key
+              - X-Api-Secret
               - X-Amz-Security-Token
               - X-Amz-User-Agent
             allowCredentials: true
@@ -300,7 +302,7 @@ functions:
           authorizer:
             name: auth
             resultTtlInSeconds: 300
-            type: token
+            type: request
           cors:
             origin: '*'
             headers:
@@ -308,6 +310,7 @@ functions:
               - X-Amz-Date
               - Authorization
               - X-Api-Key
+              - X-Api-Secret
               - X-Amz-Security-Token
               - X-Amz-User-Agent
             allowCredentials: true
@@ -321,7 +324,7 @@ functions:
           authorizer:
             name: auth
             resultTtlInSeconds: 300
-            type: token
+            type: request
           cors:
             origin: '*'
             headers:
@@ -329,6 +332,7 @@ functions:
               - X-Amz-Date
               - Authorization
               - X-Api-Key
+              - X-Api-Secret
               - X-Amz-Security-Token
               - X-Amz-User-Agent
             allowCredentials: true
@@ -342,7 +346,7 @@ functions:
           authorizer:
             name: auth
             resultTtlInSeconds: 300
-            type: token
+            type: request
           cors:
             origin: '*'
             headers:
@@ -350,6 +354,7 @@ functions:
               - X-Amz-Date
               - Authorization
               - X-Api-Key
+              - X-Api-Secret
               - X-Amz-Security-Token
               - X-Amz-User-Agent
             allowCredentials: true
@@ -434,7 +439,7 @@ resources:
           AttributeName: ttl
           Enabled: true
 
-    ApiKeysReceiptsTable:
+    ApiKeysTable:
       Type: AWS::DynamoDB::Table
       Properties:
         TableName: ${self:custom.apiKeysTable}

--- a/src/crud/delete-key.ts
+++ b/src/crud/delete-key.ts
@@ -18,11 +18,11 @@ export const handle = createApiGatewayHandler(
       );
     }
 
-    logger.info({ key }, 'deleting api key');
+    logger.info({ key: key.id }, 'deleting api key');
 
     const saved = await crud.delete(key.id);
 
-    logger.info({ key }, `deleted api key `);
+    logger.info({ key: key.id }, `deleted api key `);
 
     return { statusCode: 200 };
   }

--- a/src/crud/delete-key.ts
+++ b/src/crud/delete-key.ts
@@ -18,11 +18,11 @@ export const handle = createApiGatewayHandler(
       );
     }
 
-    logger.info({ key }, 'unsubscribed api key');
+    logger.info({ key }, 'deleting api key');
 
-    const saved = await crud.deactivate(key.id);
+    const saved = await crud.delete(key.id);
 
-    logger.info({ key }, `deactivated api key `);
+    logger.info({ key }, `deleted api key `);
 
     return { statusCode: 200 };
   }

--- a/src/util/api-key-crud.ts
+++ b/src/util/api-key-crud.ts
@@ -41,7 +41,7 @@ export default class ApiKeyCrud {
       Item: apiKey
     }).promise();
 
-    this.logger.info({ saved: Object.assign(apiKey, {secret: null}) }, 'api key created');
+    this.logger.info({ saved: {...apiKey, secret: null} }, 'api key created');
 
     return apiKey;
   }

--- a/src/util/api-key-crud.ts
+++ b/src/util/api-key-crud.ts
@@ -34,14 +34,16 @@ export default class ApiKeyCrud {
     const id = uuid.v4();
     const secret = await generateSecret(64);
 
-    const saved: ApiKey = await this.client.put({
+    const apiKey: ApiKey = { id, secret, name, scopes, user };
+
+    await this.client.put({
       TableName: API_KEYS_TABLE,
-      Item: { id, secret, name, scopes, user }
-    }).promise() as any;
+      Item: apiKey
+    }).promise();
 
-    this.logger.info({ saved }, 'api key created');
+    this.logger.info({ saved: apiKey }, 'api key created');
 
-    return saved;
+    return apiKey;
   }
 
   async get(id: string): Promise<ApiKey|null> {

--- a/src/util/api-key-crud.ts
+++ b/src/util/api-key-crud.ts
@@ -41,7 +41,7 @@ export default class ApiKeyCrud {
       Item: apiKey
     }).promise();
 
-    this.logger.info({ saved: apiKey }, 'api key created');
+    this.logger.info({ saved: Object.assign(apiKey, {secret: null}) }, 'api key created');
 
     return apiKey;
   }

--- a/src/util/env.ts
+++ b/src/util/env.ts
@@ -16,6 +16,5 @@ export const GET_ABIS_LAMBDA_NAME: string = env.get('GET_ABIS_LAMBDA_NAME').requ
 export const LOG_QUEUE_NAME: string = env.get('LOG_QUEUE_NAME').required().asString();
 export const TX_QUEUE_NAME: string = env.get('TX_QUEUE_NAME').required().asString();
 
-export const TOKEN_ISSUER: string = env.get('TOKEN_ISSUER').required().asUrlString();
-export const TOKEN_AUDIENCE: string = env.get('TOKEN_AUDIENCE').required().asUrlString();
-export const TOKEN_SECRET: string = env.get('TOKEN_SECRET').required().asString();
+export const TOKEN_ISSUER: string = env.get('TOKEN_ISSUER').required().asString();
+export const TOKEN_AUDIENCE: string = env.get('TOKEN_AUDIENCE').required().asString();


### PR DESCRIPTION
See #3 for a justification for moving to opaque keys.

This reimplements API keys as opaque keys with secrets. They are to be sent via `x-api-key` and `x-api-secret` headers, so the entire request (sans body) is now sent to the authenticator.

Because revocation no longer needs to be tracked, revoked keys are deleted from the database.

As before, this is already live on kovan.